### PR TITLE
Updates required for use in `solidus@4.4`

### DIFF
--- a/lib/solidus_digital/engine.rb
+++ b/lib/solidus_digital/engine.rb
@@ -11,6 +11,10 @@ module SolidusDigital
 
     engine_name 'solidus_digital'
 
+    initializer "solidus_digital.zeitwerk_ignore_deface_overrides", before: :eager_load! do |app|
+      app.autoloaders.main.ignore(root.join('app/overrides'))
+    end
+
     initializer "spree.register.digital_shipping" do |app|
       Rails.application.config.after_initialize do
         ::Spree::DigitalConfiguration = ::Spree::SpreeDigitalConfiguration.new

--- a/solidus_digital.gemspec
+++ b/solidus_digital.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |spec|
   spec.executables = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency 'solidus', ['>= 2.0.0']
+  spec.add_dependency 'solidus_core', ['>= 2.0.0', '< 5']
   spec.add_dependency 'solidus_support', '~> 0.5'
 
   spec.add_development_dependency 'rspec-activemodel-mocks'


### PR DESCRIPTION
* `solidus_digital.gemspec` was depending on `solidus` instead of just `solidus_core`
  * This matches the latest version of `solidus_dev_support` gemspec template
  * This also makes it so application using this gem do not have `legacy_promotions` pulled into their application.

* With `Solidus@4.4.1` an exception was being raised:
```
on_file_autoloaded': expected file solidus_digital/app/overrides/add_digital_downloads_to_invoice.rb to define constant AddDigitalDownloadsToInvoice, but didn't (Zeitwerk::NameError)
```