### PR TITLE
Update admin UI for solidus 4.4

### DIFF
--- a/app/overrides/spree/admin/shared/_order_submenu/add_digital_versions_to_admin_product_tabs.html.erb.deface
+++ b/app/overrides/spree/admin/shared/_order_submenu/add_digital_versions_to_admin_product_tabs.html.erb.deface
@@ -1,7 +1,7 @@
 <!-- insert_bottom "[data-hook='admin_order_tabs']" -->
 <% if can?(:update, @order) && @order.digital? %>
   <li>
-  <%= link_to_with_icon 'icon-cloud', I18n.t('spree.digitals.reset_downloads'), reset_digitals_admin_order_url(@order) %>
+  <%= link_to I18n.t('spree.digitals.reset_downloads'), reset_digitals_admin_order_url(@order) %>
   </li>
 <% end %>
 

--- a/app/overrides/spree/admin/shared/_product_tabs/add_digital_versions_to_admin_product_tabs.html.erb.deface
+++ b/app/overrides/spree/admin/shared/_product_tabs/add_digital_versions_to_admin_product_tabs.html.erb.deface
@@ -1,5 +1,5 @@
 <!-- insert_bottom "[data-hook='admin_product_tabs'], #admin_product_tabs[data-hook]" -->
 
-<li<%= ' class=\"active\"' if current == 'Digital Versions' %>>
-  <%= link_to_with_icon 'cloud', I18n.t('spree.digitals.digital_versions'), admin_product_digitals_path(@product) %>
-</li>
+<%= content_tag :li, class: ('active' if current == 'Digital Versions') do %>
+  <%= link_to t('spree.digitals.digital_versions'), admin_product_digitals_path(@product) %>
+<% end if can?(:admin, Spree::Digital) %>

--- a/app/views/spree/admin/digitals/_form.html.erb
+++ b/app/views/spree/admin/digitals/_form.html.erb
@@ -18,7 +18,7 @@
                 <td><%= render digital %></td>
                 <td class="actions text-right">
                   <% if can?(:destroy, Spree::Digital) %>
-                    <%= link_to_with_icon 'delete', I18n.t('spree.digitals.delete_file'), admin_product_digital_url(@product, digital), data: {confirm: I18n.t('spree.digitals.delete_file_confirmation', filename: digital.attachment_file_name)}, method: :delete, class: 'btn btn-danger btn-sm delete-resource' %>
+                    <%= link_to_delete nil, url: admin_product_digital_url(@product, digital), no_text: true, confirm: I18n.t('spree.digitals.delete_file_confirmation', filename: digital.attachment_file_name) %>
                   <% end %>
                 </td>
               </tr>

--- a/app/views/spree/admin/digitals/index.html.erb
+++ b/app/views/spree/admin/digitals/index.html.erb
@@ -1,4 +1,3 @@
-<%= render :partial => 'spree/admin/shared/product_sub_menu' %>
 <%= render :partial => 'spree/admin/shared/product_tabs', :locals => {:current => "Digital Versions"} %>
 
 <% if @product.has_variants? %>


### PR DESCRIPTION
## What does this PR do?
* Fixed a deprecation warning on `product_sub_menu`.
* The look-n-feel of this gem was not matching the latest version.  
  * The order menu was wrong anyway, so it wasn't showing the icon (`fa-icon-cloud` should have been `fa-cloud`)

## Screenshots
### Before
* Orders tab
![image](https://github.com/user-attachments/assets/89b2ece1-3f61-44b3-8da4-ca77e408a5f5)
* Digital Versions tab
![image](https://github.com/user-attachments/assets/c61ce3fd-869d-4d24-87bc-98226d6d04aa)
* Digital Link rows
![image](https://github.com/user-attachments/assets/bfca6400-bffe-419b-b06d-7d73d30e6d78)

### After
* Orders tab
![image](https://github.com/user-attachments/assets/4be77bc2-f41e-4385-a4c8-0f9d980885e5)
* Digital Versions tab
![image](https://github.com/user-attachments/assets/fecc812d-0847-497a-89c6-650ac8da1f0b)
* Digital Link rows
![image](https://github.com/user-attachments/assets/1f54cb0e-70f8-4fbc-bd2a-162ccedec0e1)
