### PR TITLE
BUGFIX: engine initialization prevented overrides in Solidus v4.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,9 @@ end
 
 Example:
 ```ruby
-Spree::DigitalConfiguration[:authorized_clicks] = nil # infinite access for user
+Rails.application.config.after_initialize do
+  Spree::DigitalConfiguration[:authorized_clicks] = nil # infinite access for user
+end
 ```
 
 ### DRM

--- a/lib/solidus_digital/engine.rb
+++ b/lib/solidus_digital/engine.rb
@@ -15,12 +15,16 @@ module SolidusDigital
       app.autoloaders.main.ignore(root.join('app/overrides'))
     end
 
-    initializer "spree.register.digital_shipping" do |app|
-      Rails.application.config.after_initialize do
-        ::Spree::DigitalConfiguration = ::Spree::SpreeDigitalConfiguration.new
-        app.config.spree.calculators.shipping_methods << ::Spree::Calculator::Shipping::DigitalDelivery
-        app.config.spree.stock_splitters << ::Spree::Stock::Splitter::DigitalSplitter
-      end
+    initializer "solidus_digital.preferences", before: "spree.environment" do |_app|
+      Spree::DigitalConfiguration = Spree::SpreeDigitalConfiguration.new
+    end
+
+    initializer "solidus_digital.digital_shipping", after: "spree.environment" do |app|
+      app.config.spree.calculators.shipping_methods << "Spree::Calculator::Shipping::DigitalDelivery"
+    end
+
+    initializer "solidus_digital.digital_splitter", after: "spree.environment" do |app|
+      app.config.spree.stock_splitters << "Spree::Stock::Splitter::DigitalSplitter"
     end
 
     # use rspec for tests


### PR DESCRIPTION
While testing with solidus v4.4, I was getting an exception trying to override configuration:

```
uninitialized constant Spree::DigitalConfiguration (NameError)

  Spree::DigitalConfiguration[:authorized_clicks] = nil
       ^^^^^^^^^^^^^^^^^^^^^^
Did you mean?  Spree::SpreeDigitalConfiguration
```

changes were made in PR #26 that I believe broke this.  While the engine "ran".....it couldn't be "configured"

This PR is a hybrid between what was there before that PR and what is required to work in v4.4